### PR TITLE
Update eslint info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Features
 * Build with [webpack 4](https://webpack.js.org/) and [babel 7](https://babeljs.io/)
 * Test with [jest](https://jestjs.io)
-* Lint with [eslint](http://eslint.org/) ([standard config](https://github.com/standard/eslint-config-standard))
+* Lint with [eslint](http://eslint.org/) (Using ["Standard JS" config](https://github.com/standard/eslint-config-standard) as default)
 * Hot reloading with [webpack-dev-server](https://webpack.js.org/configuration/dev-server/)
 
 # Getting started


### PR DESCRIPTION
Currently, it may sound like eslint default (standard) settings are used, but the specific configuration Standard JS are used by default. I updated the wording to more clearly specify that is uses Standard JS and not some other standard/default.